### PR TITLE
Anchorsets

### DIFF
--- a/src/main/kotlin/edu/kit/compiler/parser/AbstractParser.kt
+++ b/src/main/kotlin/edu/kit/compiler/parser/AbstractParser.kt
@@ -34,21 +34,72 @@ abstract class AbstractParser(tokens: Sequence<Token>) {
     /**
      * Expect and return a token of type [T].
      */
-    protected inline fun <reified T : Token> expect(): T {
-        val token = next()
+    protected inline fun <reified T : Token> expect(anc: AnchorSet): T {
+        if (peek() is T)
+            return next() as T
 
-        if (token is T)
-            return token
-        else
-            enterPanicMode()
+        println("expected ${T::class.simpleName}, but got ${peek()}")
+        panicMode(anc)
+        TODO("not implemented: lenient token")
     }
 
-    // TODO: this should probably not return `Nothing`, but this way the type system just eats it at the moment
-    protected fun enterPanicMode(): Nothing {
-        // very black magic
-        // such panic
-        // much confusing
-        // wow
-        throw IllegalArgumentException("in panic mode: *explosion sounds*")
+    /**
+     * Read a token from the token stream and expect it to be an [Token.Operator] of type [type].
+     * If this is not the case, enter [panicMode] and read from the stream until a token from [anc] is upfront.
+     */
+    protected fun expectOperator(
+        type: Token.Operator.Type,
+        anc: AnchorSet = FirstFollowUtils.emptyFirstSet
+    ): Token.Operator {
+        val peek = peek()
+        if (peek !is Token.Operator) {
+            println("expected operator ($type), but got $peek")
+            panicMode(anc)
+            TODO("not implemented: lenient token")
+        }
+
+        if (peek.type == type)
+            return next() as Token.Operator
+        else {
+            println("expected operator ($type), but got $peek")
+            panicMode(anc)
+            TODO("not implemented: lenient token")
+        }
+    }
+
+    /**
+     * Read a token and expect it to be an identifier. If it is not an identifier, enter [panicMode] and read from the
+     * token stream until a token within [anc] is upfront.
+     */
+    protected fun expectIdentifier(anc: AnchorSet): Token.Identifier = expect(anc)
+
+    /**
+     * Read a token from the token stream and expect it to be a [Token.Keyword] of type [type].
+     * If this is not the case, enter [panicMode] and read from the stream until a token from [anc] is upfront.
+     */
+    protected fun expectKeyword(type: Token.Keyword.Type, anc: AnchorSet): Token.Keyword {
+        val peek = peek()
+        if (peek !is Token.Keyword) {
+            println("expected keyword ($type), but got $peek")
+            panicMode(anc)
+            TODO("not implemented: lenient token")
+        }
+
+        if (peek.type == type)
+            return next() as Token.Keyword
+        else {
+            println("expected keyword ($type), but got $peek")
+            panicMode(anc)
+            TODO("not implemented: lenient token")
+        }
+    }
+
+    /**
+     * Read from the token stream until a token is at the front of the stream that is within the given [AnchorSet]
+     *
+     * @param anchorSet [AnchorSet] containing all tokens that are accepted as the next token in the stream.
+     */
+    protected fun panicMode(anchorSet: AnchorSet) {
+        while (peek() !in anchorSet) next()
     }
 }

--- a/src/main/kotlin/edu/kit/compiler/parser/AbstractParser.kt
+++ b/src/main/kotlin/edu/kit/compiler/parser/AbstractParser.kt
@@ -49,7 +49,7 @@ abstract class AbstractParser(tokens: Sequence<Token>) {
      */
     protected fun expectOperator(
         type: Token.Operator.Type,
-        anc: AnchorSet = FirstFollowUtils.emptyFirstSet
+        anc: AnchorSet
     ): Token.Operator {
         val peek = peek()
         if (peek !is Token.Operator) {

--- a/src/main/kotlin/edu/kit/compiler/parser/FirstFollowUtils.kt
+++ b/src/main/kotlin/edu/kit/compiler/parser/FirstFollowUtils.kt
@@ -89,6 +89,7 @@ object FirstFollowUtils {
     val firstSetLogicalOrExpression = firstSetLogicalAndExpression
     val firstSetAssignmentExpression = firstSetLogicalOrExpression
     val firstSetExpression = firstSetAssignmentExpression
+    val firstSetArguments = firstSetExpression
 
     val firstSetReturnStatement = anchorSetOf(Token.Keyword(Token.Keyword.Type.Return))
     val firstSetExpressionStatement = firstSetExpression

--- a/src/main/kotlin/edu/kit/compiler/parser/FirstFollowUtils.kt
+++ b/src/main/kotlin/edu/kit/compiler/parser/FirstFollowUtils.kt
@@ -4,10 +4,29 @@ import edu.kit.compiler.Token
 
 object FirstFollowUtils {
 
-    val firstSetProgram = anchorSetOf(Token.Keyword(Token.Keyword.Type.Class))
-    val firstSetClassDeclaration = firstSetProgram
-    val firstSetClassMember = anchorSetOf(Token.Keyword(Token.Keyword.Type.Public))
-    val firstSetMainMethod = anchorSetOf(Token.Keyword(Token.Keyword.Type.Static))
+    val emptyFirstSet = anchorSetOf()
+
+    val firstSetBasicType = anchorSetOf(
+        Token.Keyword(Token.Keyword.Type.Int),
+        Token.Keyword(Token.Keyword.Type.Boolean),
+        Token.Keyword(Token.Keyword.Type.Void),
+        Token.Identifier(""),
+    )
+    val firstSetType = firstSetBasicType
+    val firstSetParameter = firstSetType
+    val firstSetParameters = firstSetParameter
+    val firstSetMethodRest = anchorSetOf(Token.Keyword(Token.Keyword.Type.Throws))
+    val firstSetMethod = anchorSetOf(Token.Keyword(Token.Keyword.Type.Public))
+    val firstSetMainMethod = firstSetMethod
+    val firstSetField = anchorSetOf(Token.Keyword(Token.Keyword.Type.Public))
+    val firstSetClassMember = firstSetField + firstSetMethod + firstSetMainMethod
+
+    val firstSetArrayAccess = anchorSetOf(Token.Operator(Token.Operator.Type.LeftBracket))
+    val firstSetFieldAccess = anchorSetOf(Token.Operator(Token.Operator.Type.Dot))
+    val firstSetMethodInvocation = anchorSetOf(Token.Operator(Token.Operator.Type.Dot))
+    val firstSetPostfixOp = firstSetMethodInvocation + firstSetFieldAccess + firstSetArrayAccess
+    val firstSetClassDeclaration = anchorSetOf(Token.Keyword(Token.Keyword.Type.Class))
+    val firstSetProgram = firstSetClassDeclaration
 
     val firstSetNewObjectExpression = anchorSetOf(Token.Keyword(Token.Keyword.Type.New))
     val firstSetNewArrayExpression = anchorSetOf(Token.Keyword(Token.Keyword.Type.New))
@@ -21,6 +40,31 @@ object FirstFollowUtils {
             Token.Keyword(Token.Keyword.Type.This),
             Token.Operator(Token.Operator.Type.LParen)
         ) + firstSetNewArrayExpression + firstSetNewObjectExpression
+    val firstSetPostfixExpression = firstSetPrimaryExpression
+    val firstSetUnaryExpression = anchorSetOf(
+        Token.Operator(Token.Operator.Type.Not),
+        Token.Operator(Token.Operator.Type.Minus)
+    ) + firstSetPostfixExpression
+    val firstSetTypeArrayRecurse = anchorSetOf(Token.Operator(Token.Operator.Type.LeftBracket))
+    val firstSetMultiplicativeExpression = firstSetUnaryExpression
+    val firstSetAdditiveExpression = firstSetMultiplicativeExpression
+    val firstSetRelationalExpression = firstSetAdditiveExpression
+    val firstSetEqualityExpression = firstSetRelationalExpression
+    val firstSetLogicalAndExpression = firstSetEqualityExpression
+    val firstSetLogicalOrExpression = firstSetLogicalAndExpression
+    val firstSetAssignmentExpression = firstSetLogicalOrExpression
+    val firstSetExpression = firstSetAssignmentExpression
+
+    val firstSetReturnStatement = anchorSetOf(Token.Keyword(Token.Keyword.Type.Return))
+    val firstSetExpressionStatement = firstSetExpression
+    val firstSetIfStatement = anchorSetOf(Token.Keyword(Token.Keyword.Type.If))
+    val firstSetWhileStatement = anchorSetOf(Token.Keyword(Token.Keyword.Type.While))
+    val firstSetEmptyStatement = anchorSetOf(Token.Operator(Token.Operator.Type.Semicolon))
+    val firstSetLocalVariableDeclarationStatement = firstSetType
+    val firstSetBlock = anchorSetOf(Token.Operator(Token.Operator.Type.LeftBrace))
+    val firstSetStatement =
+        firstSetBlock + firstSetEmptyStatement + firstSetIfStatement + firstSetExpressionStatement + firstSetWhileStatement + firstSetReturnStatement
+    val firstSetBlockStatement = firstSetStatement + firstSetLocalVariableDeclarationStatement
 }
 
 @JvmInline

--- a/src/main/kotlin/edu/kit/compiler/parser/FirstFollowUtils.kt
+++ b/src/main/kotlin/edu/kit/compiler/parser/FirstFollowUtils.kt
@@ -45,11 +45,15 @@ value class AnchorSet(val tokens: Set<Token>) {
     /**
      * Union operator for two [AnchorSets][AnchorSet]
      */
-    operator fun plus(anchorSet: AnchorSet): AnchorSet =
-        AnchorSet(this.tokens.union(anchorSet.tokens))
+    operator fun plus(anchorSet: AnchorSet): AnchorSet = AnchorSet(this.tokens.union(anchorSet.tokens))
+
+    /**
+     * `in` operator for this set
+     */
+    operator fun contains(t: Token): Boolean = t in tokens
 }
 
 /**
  * Construct an [AnchorSet] from a variadic array of tokens
  */
-private fun anchorSetOf(vararg tokens: Token) = AnchorSet(tokens.toSet())
+fun anchorSetOf(vararg tokens: Token) = AnchorSet(tokens.toSet())

--- a/src/main/kotlin/edu/kit/compiler/parser/FirstFollowUtils.kt
+++ b/src/main/kotlin/edu/kit/compiler/parser/FirstFollowUtils.kt
@@ -4,10 +4,23 @@ import edu.kit.compiler.Token
 
 object FirstFollowUtils {
 
-    val firstSets: Array<AnchorSet> = arrayOf(
-        // parse program:
-        anchorSetOf()
-    )
+    val firstSetProgram = anchorSetOf(Token.Keyword(Token.Keyword.Type.Class))
+    val firstSetClassDeclaration = firstSetProgram
+    val firstSetClassMember = anchorSetOf(Token.Keyword(Token.Keyword.Type.Public))
+    val firstSetMainMethod = anchorSetOf(Token.Keyword(Token.Keyword.Type.Static))
+
+    val firstSetNewObjectExpression = anchorSetOf(Token.Keyword(Token.Keyword.Type.New))
+    val firstSetNewArrayExpression = anchorSetOf(Token.Keyword(Token.Keyword.Type.New))
+    val firstSetPrimaryExpression =
+        anchorSetOf(
+            Token.Keyword(Token.Keyword.Type.Null),
+            Token.Keyword(Token.Keyword.Type.False),
+            Token.Keyword(Token.Keyword.Type.True),
+            Token.Literal(""),
+            Token.Identifier(""),
+            Token.Keyword(Token.Keyword.Type.This),
+            Token.Operator(Token.Operator.Type.LParen)
+        ) + firstSetNewArrayExpression + firstSetNewObjectExpression
 }
 
 @JvmInline

--- a/src/main/kotlin/edu/kit/compiler/parser/FirstFollowUtils.kt
+++ b/src/main/kotlin/edu/kit/compiler/parser/FirstFollowUtils.kt
@@ -1,0 +1,42 @@
+package edu.kit.compiler.parser
+
+import edu.kit.compiler.Token
+
+object FirstFollowUtils {
+
+    val firstSets: Array<AnchorSet> = arrayOf(
+        // parse program:
+        anchorSetOf()
+    )
+}
+
+@JvmInline
+value class AnchorSet(val tokens: Array<out Token>) {
+    /**
+     * @param token a token to check against this [AnchorSet]
+     * @return true, if the given token type is within this anchor set.
+     */
+    fun isInSet(token: Token): Boolean {
+        return when (token) {
+            is Token.Identifier -> tokens.any { it is Token.Identifier }
+            is Token.Literal -> tokens.any { it is Token.Literal }
+            Token.Eof -> token in tokens
+            is Token.ErrorToken -> false
+            is Token.Keyword -> token.type in tokens.mapNotNull { (it as? Token.Keyword)?.type }
+            is Token.Operator -> token.type in tokens.mapNotNull { (it as? Token.Operator)?.type }
+            is Token.Whitespace -> error("whitespace tokens should not be checked against anchor sets")
+            is Token.Comment -> error("comment tokens should not be checked against anchor sets")
+        }
+    }
+
+    /**
+     * Union operator for two [AnchorSets][AnchorSet]
+     */
+    operator fun plus(anchorSet: AnchorSet): AnchorSet =
+        AnchorSet(setOf(*this.tokens, *anchorSet.tokens).toTypedArray())
+}
+
+/**
+ * Construct an [AnchorSet] from a variadic array of tokens
+ */
+private fun anchorSetOf(vararg tokens: Token) = AnchorSet(tokens)

--- a/src/main/kotlin/edu/kit/compiler/parser/FirstFollowUtils.kt
+++ b/src/main/kotlin/edu/kit/compiler/parser/FirstFollowUtils.kt
@@ -24,7 +24,7 @@ object FirstFollowUtils {
 }
 
 @JvmInline
-value class AnchorSet(val tokens: Array<out Token>) {
+value class AnchorSet(val tokens: Set<Token>) {
     /**
      * @param token a token to check against this [AnchorSet]
      * @return true, if the given token type is within this anchor set.
@@ -46,10 +46,10 @@ value class AnchorSet(val tokens: Array<out Token>) {
      * Union operator for two [AnchorSets][AnchorSet]
      */
     operator fun plus(anchorSet: AnchorSet): AnchorSet =
-        AnchorSet(setOf(*this.tokens, *anchorSet.tokens).toTypedArray())
+        AnchorSet(this.tokens.union(anchorSet.tokens))
 }
 
 /**
  * Construct an [AnchorSet] from a variadic array of tokens
  */
-private fun anchorSetOf(vararg tokens: Token) = AnchorSet(tokens)
+private fun anchorSetOf(vararg tokens: Token) = AnchorSet(tokens.toSet())

--- a/src/main/kotlin/edu/kit/compiler/parser/FirstFollowUtils.kt
+++ b/src/main/kotlin/edu/kit/compiler/parser/FirstFollowUtils.kt
@@ -4,7 +4,45 @@ import edu.kit.compiler.Token
 
 object FirstFollowUtils {
 
-    val emptyFirstSet = anchorSetOf()
+    val allExpressionOperators = anchorSetOf(
+        Token.Operator(Token.Operator.Type.NoEq),
+        Token.Operator(Token.Operator.Type.Not),
+        Token.Operator(Token.Operator.Type.LParen),
+        Token.Operator(Token.Operator.Type.RParen),
+        Token.Operator(Token.Operator.Type.MulAssign),
+        Token.Operator(Token.Operator.Type.Mul),
+        Token.Operator(Token.Operator.Type.PlusPlus),
+        Token.Operator(Token.Operator.Type.PlusAssign),
+        Token.Operator(Token.Operator.Type.Plus),
+        Token.Operator(Token.Operator.Type.MinusAssign),
+        Token.Operator(Token.Operator.Type.MinusMinus),
+        Token.Operator(Token.Operator.Type.Minus),
+        Token.Operator(Token.Operator.Type.DivAssign),
+        Token.Operator(Token.Operator.Type.Div),
+        Token.Operator(Token.Operator.Type.LeftShiftAssign),
+        Token.Operator(Token.Operator.Type.LeftShift),
+        Token.Operator(Token.Operator.Type.LtEq),
+        Token.Operator(Token.Operator.Type.Lt),
+        Token.Operator(Token.Operator.Type.Eq),
+        Token.Operator(Token.Operator.Type.Assign),
+        Token.Operator(Token.Operator.Type.GtEq),
+        Token.Operator(Token.Operator.Type.RightShiftSEAssign),
+        Token.Operator(Token.Operator.Type.RightShiftAssign),
+        Token.Operator(Token.Operator.Type.RightShift),
+        Token.Operator(Token.Operator.Type.RightShiftSE),
+        Token.Operator(Token.Operator.Type.Gt),
+        Token.Operator(Token.Operator.Type.ModAssign),
+        Token.Operator(Token.Operator.Type.Mod),
+        Token.Operator(Token.Operator.Type.AndAssign),
+        Token.Operator(Token.Operator.Type.And),
+        Token.Operator(Token.Operator.Type.BitAnd),
+        Token.Operator(Token.Operator.Type.XorAssign),
+        Token.Operator(Token.Operator.Type.Xor),
+        Token.Operator(Token.Operator.Type.BitNot),
+        Token.Operator(Token.Operator.Type.OrAssign),
+        Token.Operator(Token.Operator.Type.Or),
+        Token.Operator(Token.Operator.Type.BitOr)
+    )
 
     val firstSetBasicType = anchorSetOf(
         Token.Keyword(Token.Keyword.Type.Int),
@@ -14,19 +52,16 @@ object FirstFollowUtils {
     )
     val firstSetType = firstSetBasicType
     val firstSetParameter = firstSetType
-    val firstSetParameters = firstSetParameter
-    val firstSetMethodRest = anchorSetOf(Token.Keyword(Token.Keyword.Type.Throws))
     val firstSetMethod = anchorSetOf(Token.Keyword(Token.Keyword.Type.Public))
     val firstSetMainMethod = firstSetMethod
     val firstSetField = anchorSetOf(Token.Keyword(Token.Keyword.Type.Public))
     val firstSetClassMember = firstSetField + firstSetMethod + firstSetMainMethod
+    val firstSetClassMembers = firstSetClassMember
 
     val firstSetArrayAccess = anchorSetOf(Token.Operator(Token.Operator.Type.LeftBracket))
     val firstSetFieldAccess = anchorSetOf(Token.Operator(Token.Operator.Type.Dot))
     val firstSetMethodInvocation = anchorSetOf(Token.Operator(Token.Operator.Type.Dot))
     val firstSetPostfixOp = firstSetMethodInvocation + firstSetFieldAccess + firstSetArrayAccess
-    val firstSetClassDeclaration = anchorSetOf(Token.Keyword(Token.Keyword.Type.Class))
-    val firstSetProgram = firstSetClassDeclaration
 
     val firstSetNewObjectExpression = anchorSetOf(Token.Keyword(Token.Keyword.Type.New))
     val firstSetNewArrayExpression = anchorSetOf(Token.Keyword(Token.Keyword.Type.New))

--- a/src/test/kotlin/edu/kit/compiler/parser/ExpressionParseTest.kt
+++ b/src/test/kotlin/edu/kit/compiler/parser/ExpressionParseTest.kt
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.Test
 
 @ExperimentalStdlibApi
 internal class ExpressionParseTest {
+    private val emptyAnchorSet = anchorSetOf()
+
     private fun expectAst(input: String, expectedAST: AST.Expression) =
-        expectNode(input, expectedAST) { parseExpression() }
+        expectNode(input, expectedAST) { parseExpression(anc = emptyAnchorSet) }
 
     @Test
     fun testParseLiteral() = expectAst("1", AST.LiteralExpression("1"))

--- a/src/test/kotlin/edu/kit/compiler/parser/MixedParseTest.kt
+++ b/src/test/kotlin/edu/kit/compiler/parser/MixedParseTest.kt
@@ -10,24 +10,27 @@ import kotlin.test.Ignore
 @ExperimentalStdlibApi
 internal class MixedParseTest {
 
+    private val emptyAnchorSet = anchorSetOf()
+
     private fun expectAst(input: String, expectedAST: List<AST.ClassDeclaration>) =
-        expectNode(input, expectedAST) { parseClassDeclarations() }
+        expectNode(input, expectedAST) { parseClassDeclarations(emptyAnchorSet) }
 
     @Test
-    fun testParseEmptyBlock() = expectNode("{}", AST.Block(listOf())) { parseBlock() }
+    fun testParseEmptyBlock() = expectNode("{}", AST.Block(listOf())) { parseBlock(emptyAnchorSet) }
 
     @Test
     fun testParseBlockOfEmptyBlocks() =
-        expectNode("{{{}}}", AST.Block(listOf(AST.Block(listOf(AST.Block(listOf())))))) { parseBlock() }
+        expectNode("{{{}}}", AST.Block(listOf(AST.Block(listOf(AST.Block(listOf())))))) { parseBlock(emptyAnchorSet) }
 
     @Test
-    fun testParseBlockWithEmptyStatement() = expectNode("{;}", AST.Block(listOf(AST.EmptyStatement))) { parseBlock() }
+    fun testParseBlockWithEmptyStatement() =
+        expectNode("{;}", AST.Block(listOf(AST.EmptyStatement))) { parseBlock(emptyAnchorSet) }
 
     @Test
     fun testParseBlockWithMultipleEmptyStatement() = expectNode(
         "{;;;;}",
         AST.Block(listOf(AST.EmptyStatement, AST.EmptyStatement, AST.EmptyStatement, AST.EmptyStatement))
-    ) { parseBlock() }
+    ) { parseBlock(emptyAnchorSet) }
 
     @Test
     fun testDisambiguateVarDeclarationAndExpression() = expectNode(
@@ -38,7 +41,7 @@ internal class MixedParseTest {
                 AST.LocalVariableDeclarationStatement("myident2", Type.ClassType("mytype"), null)
             )
         )
-    ) { parseBlock() }
+    ) { parseBlock(emptyAnchorSet) }
 
     @Test
     fun testParseAssignment() = expectNode(
@@ -50,49 +53,49 @@ internal class MixedParseTest {
                 AST.BinaryExpression.Operation.ASSIGNMENT
             )
         )
-    ) { parseStatement() }
+    ) { parseStatement(emptyAnchorSet) }
 
     @Test
     fun testParseReturn() = expectNode(
         "return;",
         AST.ReturnStatement(null)
-    ) { parseStatement() }
+    ) { parseStatement(emptyAnchorSet) }
 
     @Test
     fun testParseReturnValue() = expectNode(
         "return(2);",
         AST.ReturnStatement(AST.LiteralExpression("2"))
-    ) { parseStatement() }
+    ) { parseStatement(emptyAnchorSet) }
 
     @Test
     fun testParseBasicWhile() = expectNode(
         "while(2) {};",
         AST.WhileStatement(AST.LiteralExpression("2"), AST.Block(listOf()))
-    ) { parseStatement() }
+    ) { parseStatement(emptyAnchorSet) }
 
     @Test
     fun testParseBasicIf() = expectNode(
         "if(2) {};",
         AST.IfStatement(AST.LiteralExpression("2"), AST.Block(listOf()), null)
-    ) { parseStatement() }
+    ) { parseStatement(emptyAnchorSet) }
 
     @Test
     fun testParseBasicIfElse() = expectNode(
         "if(2) {} else {};",
         AST.IfStatement(AST.LiteralExpression("2"), AST.Block(listOf()), AST.Block(listOf()))
-    ) { parseStatement() }
+    ) { parseStatement(emptyAnchorSet) }
 
     @Test
     fun testParseBasicIfElse_bool() = expectNode(
         "if(true) {} else {};",
         AST.IfStatement(AST.LiteralExpression(true), AST.Block(listOf()), AST.Block(listOf()))
-    ) { parseStatement() }
+    ) { parseStatement(emptyAnchorSet) }
 
     @Test
     fun testParseBasicIfElse_ident() = expectNode(
         "if(myIdent) {} else {};",
         AST.IfStatement(AST.IdentifierExpression("myIdent"), AST.Block(listOf()), AST.Block(listOf()))
-    ) { parseStatement() }
+    ) { parseStatement(emptyAnchorSet) }
 
     @Test
     fun debugParserMJTest_2() = expectNode(
@@ -187,7 +190,7 @@ internal class MixedParseTest {
 
     ) { parse() }
 
-//    @Ignore
+    //    @Ignore
     @Test
     fun debugParserMJTest_ArrayAccessValid() = expectNode(
         """class Test {


### PR DESCRIPTION
Parser ist umimplementiert mit Fehlerrecovery und Wiederaufsetzen. Beim Wiederaufsetzen werden jedoch momentan sofort `NotImplmenetedException`s geworfen, weil die `Lenient` AST Strukturen noch fehlen.
Testcases sind grün, Ankermengen werden noch nicht getestet.