### PR TITLE
Add SourceSpans to parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ subset of Java.
 
 ## Documentation
 
-- [MiniJava Syntax](./docs/parser/MiniJava%20Syntax.md): left-factorized Grammar, `First` and `Follow` sets
+- [MiniJava Syntax](./docs/parser/MiniJava%20-%20Syntax.md): left-factorized Grammar, `First` and `Follow` sets
 - [Lexer DEA](./docs/LexerDEA.svg): deterministic automata for the lexer
 - [Wrapper AST Prototype](./docs/parser/WrappedAstPrototype.hs): Wrapper prototype written in haskell
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,12 +45,12 @@ dependencies {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
         freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
-        jvmTarget = "16"
+        jvmTarget = "17"
     }
 }
 
 java {
-    targetCompatibility = JavaVersion.VERSION_16
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 }
 
 java {
-    targetCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_16
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
         freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
-        jvmTarget = "17"
+        jvmTarget = "16"
     }
 }
 

--- a/src/main/kotlin/edu/kit/compiler/ast/AbstractASTVisitor.kt
+++ b/src/main/kotlin/edu/kit/compiler/ast/AbstractASTVisitor.kt
@@ -3,7 +3,6 @@ package edu.kit.compiler.ast
 import edu.kit.compiler.wrapper.Unwrappable
 import edu.kit.compiler.wrapper.into
 import edu.kit.compiler.wrapper.unwrap
-import edu.kit.compiler.wrapper.wrappers.into
 
 abstract class AbstractASTVisitor<ExprW, StmtW, DeclW, ClassW, OtherW>(
     private val unwrapExpr: Unwrappable<ExprW>,
@@ -11,128 +10,302 @@ abstract class AbstractASTVisitor<ExprW, StmtW, DeclW, ClassW, OtherW>(
     private val unwrapDecl: Unwrappable<DeclW>,
     private val unwrapClass: Unwrappable<ClassW>,
     private val unwrapOther: Unwrappable<OtherW>
-) :
-    ASTVisitor<ExprW, StmtW, DeclW, ClassW, OtherW> {
+) : ASTVisitor<ExprW, StmtW, DeclW, ClassW, OtherW> {
+
+    // AST.Program
+    protected fun AST.Program<ExprW, StmtW, DeclW, ClassW, OtherW>.descendClasses() {
+        classes.forEach { it.unwrap(unwrapClass).accept(this@AbstractASTVisitor) }
+    }
+
     override fun visit(program: AST.Program<ExprW, StmtW, DeclW, ClassW, OtherW>) {
-        program.classes.forEach { it.unwrap(unwrapClass).accept(this) }
+        program.descendClasses()
+    }
+
+    // AST.ClassDeclaration
+    protected fun AST.ClassDeclaration<ExprW, StmtW, DeclW, OtherW>.descendMembers() {
+        member.forEach { it.unwrap(unwrapDecl).accept(this@AbstractASTVisitor) }
     }
 
     override fun visit(classDeclaration: AST.ClassDeclaration<ExprW, StmtW, DeclW, OtherW>) {
-        classDeclaration.member.forEach { it.unwrap(unwrapDecl).accept(this) }
+        classDeclaration.descendMembers()
+    }
+
+    // AST.Field
+    protected fun AST.Field<OtherW>.descendType() {
+        type.unwrap(unwrapOther).into().accept(this@AbstractASTVisitor)
     }
 
     override fun visit(field: AST.Field<OtherW>) {
-        field.type.unwrap(unwrapOther).into().accept(this)
+        field.descendType()
+    }
+
+    // AST.Method
+    protected fun AST.Method<ExprW, StmtW, OtherW>.descendReturnType() {
+        returnType.unwrap(unwrapOther).into().accept(this@AbstractASTVisitor)
+    }
+
+    protected fun AST.Method<ExprW, StmtW, OtherW>.descendParameters() {
+        parameters.forEach { it.unwrap(unwrapOther).into().accept(this@AbstractASTVisitor) }
+    }
+
+    protected fun AST.Method<ExprW, StmtW, OtherW>.descendBlock() {
+        block.unwrap(unwrapStmt).accept(this@AbstractASTVisitor)
     }
 
     override fun visit(method: AST.Method<ExprW, StmtW, OtherW>) {
-        method.returnType.unwrap(unwrapOther).into().accept(this)
-        method.parameters.forEach { it.unwrap(unwrapOther).into().accept(this) }
-        method.block.unwrap(unwrapStmt).accept(this)
+        method.descendReturnType()
+        method.descendParameters()
+        method.descendBlock()
+    }
+
+    // AST.MainMethod
+    protected fun AST.MainMethod<ExprW, StmtW, OtherW>.descendReturnType() {
+        returnType.unwrap(unwrapOther).into().accept(this@AbstractASTVisitor)
+    }
+
+    protected fun AST.MainMethod<ExprW, StmtW, OtherW>.descendParameters() {
+        parameters.forEach { it.unwrap(unwrapOther).into().accept(this@AbstractASTVisitor) }
+    }
+
+    protected fun AST.MainMethod<ExprW, StmtW, OtherW>.descendBlock() {
+        block.unwrap(unwrapStmt).accept(this@AbstractASTVisitor)
     }
 
     override fun visit(mainMethod: AST.MainMethod<ExprW, StmtW, OtherW>) {
-        mainMethod.returnType.unwrap(unwrapOther).into().accept(this)
-        mainMethod.parameters.forEach { it.unwrap(unwrapOther).into().accept(this) }
-        mainMethod.block.unwrap(unwrapStmt).accept(this)
+        mainMethod.descendReturnType()
+        mainMethod.descendParameters()
+        mainMethod.descendBlock()
+    }
+
+    // AST.Parameter
+    protected fun AST.Parameter<OtherW>.descendType() {
+        type.unwrap(unwrapOther).into().accept(this@AbstractASTVisitor)
     }
 
     override fun visit(parameter: AST.Parameter<OtherW>) {
-        parameter.type.unwrap(unwrapOther).into().accept(this)
+        parameter.descendType()
+    }
+
+    // AST.LocalVariableDeclarationStatement
+    protected fun AST.LocalVariableDeclarationStatement<ExprW, OtherW>.descendType() {
+        type.unwrap(unwrapOther).into().accept(this@AbstractASTVisitor)
+    }
+
+    protected fun AST.LocalVariableDeclarationStatement<ExprW, OtherW>.descendInitializer() {
+        initializer?.also { it.unwrap(unwrapExpr).into().accept(this@AbstractASTVisitor) }
     }
 
     override fun visit(localVariableDeclarationStatement: AST.LocalVariableDeclarationStatement<ExprW, OtherW>) {
-        localVariableDeclarationStatement.type.unwrap(unwrapOther).into().accept(this)
-        localVariableDeclarationStatement.initializer?.also { it.unwrap(unwrapExpr) }
+        localVariableDeclarationStatement.descendType()
+        localVariableDeclarationStatement.descendInitializer()
+    }
+
+    // AST.Block
+    protected fun AST.Block<ExprW, StmtW, OtherW>.descendStatements() {
+        statements.forEach { it.unwrap(unwrapStmt).into().accept(this@AbstractASTVisitor) }
     }
 
     override fun visit(block: AST.Block<ExprW, StmtW, OtherW>) {
-        block.statements.forEach { it.unwrap(unwrapStmt).into() }
+        block.descendStatements()
+    }
+
+    // AST.IfStatement
+    protected fun AST.IfStatement<ExprW, StmtW, OtherW>.descendCondition() {
+        condition.unwrap(unwrapExpr).into().accept(this@AbstractASTVisitor)
+    }
+
+    protected fun AST.IfStatement<ExprW, StmtW, OtherW>.descendTrueStatement() {
+        trueStatement.unwrap(unwrapStmt).into().accept(this@AbstractASTVisitor)
+    }
+
+    fun AST.IfStatement<ExprW, StmtW, OtherW>.descendFalseStatement() {
+        falseStatement?.also { it.unwrap(unwrapStmt).into().accept(this@AbstractASTVisitor) }
     }
 
     override fun visit(ifStatement: AST.IfStatement<ExprW, StmtW, OtherW>) {
-        ifStatement.condition.unwrap(unwrapExpr).into().accept(this)
-        ifStatement.trueStatement.unwrap(unwrapStmt).into().accept(this)
-        ifStatement.falseStatement?.also { it.unwrap(unwrapStmt).into().accept(this) }
+        ifStatement.descendCondition()
+        ifStatement.descendTrueStatement()
+        ifStatement.descendFalseStatement()
+    }
+
+    // AST.WhileStatement
+    protected fun AST.WhileStatement<ExprW, StmtW, OtherW>.descendCondition() {
+        condition.unwrap(unwrapExpr).into().accept(this@AbstractASTVisitor)
+    }
+
+    protected fun AST.WhileStatement<ExprW, StmtW, OtherW>.descendStatement() {
+        statement.unwrap(unwrapStmt).into().accept(this@AbstractASTVisitor)
     }
 
     override fun visit(whileStatement: AST.WhileStatement<ExprW, StmtW, OtherW>) {
-        whileStatement.condition.unwrap(unwrapExpr).into().accept(this)
-        whileStatement.statement.unwrap(unwrapStmt).into().accept(this)
+        whileStatement.descendCondition()
+        whileStatement.descendStatement()
+    }
+
+    // AST.ReturnStatement
+    protected fun AST.ReturnStatement<ExprW, OtherW>.descendExpression() {
+        expression?.also { it.unwrap(unwrapExpr).into().accept(this@AbstractASTVisitor) }
     }
 
     override fun visit(returnStatement: AST.ReturnStatement<ExprW, OtherW>) {
-        returnStatement.expression?.also { it.unwrap(unwrapExpr).into().accept(this) }
+        returnStatement.descendExpression()
+    }
+
+    // AST.BinaryExpression
+    protected fun AST.BinaryExpression<ExprW, OtherW>.descendLeft() {
+        left.unwrap(unwrapExpr).into().accept(this@AbstractASTVisitor)
+    }
+
+    protected fun AST.BinaryExpression<ExprW, OtherW>.descendRight() {
+        right.unwrap(unwrapExpr).into().accept(this@AbstractASTVisitor)
+    }
+
+    protected fun AST.BinaryExpression<ExprW, OtherW>.descendOperation() {
+        operation.accept(this@AbstractASTVisitor)
     }
 
     override fun visit(binaryExpression: AST.BinaryExpression<ExprW, OtherW>) {
-        binaryExpression.left.unwrap(unwrapExpr).into().accept(this)
-        binaryExpression.right.unwrap(unwrapExpr).into().accept(this)
-        binaryExpression.operation.accept(this)
+        binaryExpression.descendLeft()
+        binaryExpression.descendOperation()
+        binaryExpression.descendRight()
+    }
+
+    // AST.UnaryExpression
+    protected fun AST.UnaryExpression<ExprW, OtherW>.descendExpression() {
+        expression.unwrap(unwrapExpr).into().accept(this@AbstractASTVisitor)
+    }
+
+    protected fun AST.UnaryExpression<ExprW, OtherW>.descendOperation() {
+        operation.accept(this@AbstractASTVisitor)
     }
 
     override fun visit(unaryExpression: AST.UnaryExpression<ExprW, OtherW>) {
-        unaryExpression.expression.unwrap(unwrapExpr).into().accept(this)
-        unaryExpression.operation.accept(this)
+        unaryExpression.descendOperation()
+        unaryExpression.descendExpression()
+    }
+
+    // AST.MethodInvocationExpression
+    protected fun AST.MethodInvocationExpression<ExprW, OtherW>.descendTarget() {
+        target?.also { it.unwrap(unwrapExpr).into().accept(this@AbstractASTVisitor) }
+    }
+
+    protected fun AST.MethodInvocationExpression<ExprW, OtherW>.descendArguments() {
+        arguments.forEach { it.unwrap(unwrapExpr).into().accept(this@AbstractASTVisitor) }
     }
 
     override fun visit(methodInvocationExpression: AST.MethodInvocationExpression<ExprW, OtherW>) {
-        methodInvocationExpression.target?.also { it.unwrap(unwrapExpr).into().accept(this) }
-        methodInvocationExpression.arguments.forEach { it.unwrap(unwrapExpr).into().accept(this) }
+        methodInvocationExpression.descendTarget()
+        methodInvocationExpression.descendArguments()
+    }
+
+    // AST.FieldAccessExpression
+    protected fun AST.FieldAccessExpression<ExprW, OtherW>.descendTarget() {
+        target.unwrap(unwrapExpr).into().accept(this@AbstractASTVisitor)
     }
 
     override fun visit(fieldAccessExpression: AST.FieldAccessExpression<ExprW, OtherW>) {
-        fieldAccessExpression.target.unwrap(unwrapExpr).into().accept(this)
+        fieldAccessExpression.descendTarget()
+    }
+
+    // AST.ArrayAccessExpression
+    protected fun AST.ArrayAccessExpression<ExprW, OtherW>.descendTarget() {
+        target.unwrap(unwrapExpr).into().accept(this@AbstractASTVisitor)
+    }
+
+    protected fun AST.ArrayAccessExpression<ExprW, OtherW>.descendIndexExpression() {
+        index.unwrap(unwrapExpr).into().accept(this@AbstractASTVisitor)
     }
 
     override fun visit(arrayAccessExpression: AST.ArrayAccessExpression<ExprW, OtherW>) {
-        arrayAccessExpression.index.unwrap(unwrapExpr).into().accept(this)
-        arrayAccessExpression.target.unwrap(unwrapExpr).into().accept(this)
+        arrayAccessExpression.descendTarget()
+        arrayAccessExpression.descendIndexExpression()
     }
 
+    // AST.IdentifierExpression
     override fun visit(identifierExpression: AST.IdentifierExpression) {
         // Nothing to do
     }
 
+    // AST.LiteralExpression
     override fun <T> visit(literalExpression: AST.LiteralExpression<T>) {
         // Nothing to do
     }
 
+    // AST.NewObjectExpression
     override fun visit(newObjectExpression: AST.NewObjectExpression) {
         // Nothing to do
     }
 
-    override fun visit(newArrayExpression: AST.NewArrayExpression<ExprW, OtherW>) {
-        newArrayExpression.type.unwrap(unwrapOther).into().accept(this)
-        newArrayExpression.length.unwrap(unwrapExpr).into().accept(this)
+    // AST.NewArrayExpression
+    protected fun AST.NewArrayExpression<ExprW, OtherW>.descendType() {
+        type.unwrap(unwrapOther).into().accept(this@AbstractASTVisitor)
     }
 
+    protected fun AST.NewArrayExpression<ExprW, OtherW>.descendLength() {
+        length.unwrap(unwrapExpr).into().accept(this@AbstractASTVisitor)
+    }
+
+    override fun visit(newArrayExpression: AST.NewArrayExpression<ExprW, OtherW>) {
+        newArrayExpression.descendType()
+        newArrayExpression.descendLength()
+    }
+
+    // Type.Void
     override fun visit(voidType: Type.Void) {
         // Nothing to do
     }
 
+    // Type.Integer
     override fun visit(integerType: Type.Integer) {
         // Nothing to do
     }
 
+    // Type.Boolean
     override fun visit(booleanType: Type.Boolean) {
         // Nothing to do
     }
 
-    override fun visit(arrayType: Type.Array<OtherW>) {
-        arrayType.arrayType.accept(this)
+    // Type.Array
+    protected fun Type.Array<OtherW>.descendType() {
+        arrayType.descendElementType()
+        // arrayType.accept(this@AbstractASTVisitor)
     }
 
+    override fun visit(arrayType: Type.Array<OtherW>) {
+        arrayType.descendType()
+    }
+
+    // Type.Array.ArrayType
+    protected fun Type.Array.ArrayType<OtherW>.descendElementType() {
+        elementType.unwrap(unwrapOther).into().accept(this@AbstractASTVisitor)
+    }
+
+    override fun visit(arrayType: Type.Array.ArrayType<OtherW>) {
+        arrayType.descendElementType()
+    }
+
+    // Type.Class
     override fun visit(classType: Type.Class) {
         // Nothing to do
     }
 
+    // AST.BinaryExpression.Operation
     override fun visit(operation: AST.BinaryExpression.Operation) {
         // Nothing to do
     }
 
+    // AST.UnaryExpression.Operation
+    override fun visit(operation: AST.UnaryExpression.Operation) {
+        // Nothing to do
+    }
+
+    // AST.ExpressionStatement
+    protected fun AST.ExpressionStatement<ExprW, OtherW>.descendExpression() {
+        expression.unwrap(unwrapExpr).into().accept(this@AbstractASTVisitor)
+    }
+
     override fun visit(expressionStatement: AST.ExpressionStatement<ExprW, OtherW>) {
-        expressionStatement.expression.unwrap(unwrapExpr).into().accept(this)
+        expressionStatement.descendExpression()
     }
 }
 

--- a/src/main/kotlin/edu/kit/compiler/parser/AbstractParser.kt
+++ b/src/main/kotlin/edu/kit/compiler/parser/AbstractParser.kt
@@ -73,12 +73,12 @@ abstract class AbstractParser(tokens: Sequence<Token>, protected val sourceFile:
         errorMsg: () -> String
     ): Positioned<Token.Operator?> {
         val peeked = peek()
-        val sourceRange = SourceRange(peeked.position, 1).extend(SourceRange(peek(1).position, 1))
         if (peeked !is Token.Operator) {
             reportError(peeked, errorMsg())
             recover(anc)
-            return null.positioned(sourceRange)
+            return null.positioned(peeked.range)
         }
+        val sourceRange = SourceRange(peeked.position, 1).extend(SourceRange(peek(1).position, 1))
 
         return if (peeked.type == type)
             (next() as Token.Operator)

--- a/src/main/kotlin/edu/kit/compiler/parser/Parser.kt
+++ b/src/main/kotlin/edu/kit/compiler/parser/Parser.kt
@@ -284,7 +284,7 @@ class Parser(sourceFile: SourceFile, tokens: Sequence<Token>) :
             } else {
                 basicType
             }
-        }else {
+        } else {
             basicType
         }
     }

--- a/src/main/kotlin/edu/kit/compiler/parser/Parser.kt
+++ b/src/main/kotlin/edu/kit/compiler/parser/Parser.kt
@@ -868,7 +868,7 @@ class Parser(sourceFile: SourceFile, tokens: Sequence<Token>) :
                 block,
                 throwsException?.orElse(null)
             ).wrapErroneous()
-        }.positioned(ident.get().range.extend(block.unCompose.annotation)).compose()
+        }.positioned(type.unCompose.into().annotation.extend(block.unCompose.annotation)).compose()
     }
 
     internal fun parseBlock(anc: AnchorUnion): Parsed<ParsedBlock> {

--- a/src/main/kotlin/edu/kit/compiler/wrapper/TypeAliases.kt
+++ b/src/main/kotlin/edu/kit/compiler/wrapper/TypeAliases.kt
@@ -18,7 +18,7 @@ import edu.kit.compiler.wrapper.wrappers.Positioned
 /** Type containing [Lenient]s */
 typealias LenientType = Type<Lenient<Of>>
 /** Array containing [Lenient]s */
-typealias LenientArray = Array<Lenient<Of>>
+typealias LenientArray = Type.Array<Lenient<Of>>
 /** ArrayType.ArrayType containing [Lenient]s */
 typealias LenientArrayType = Type.Array.ArrayType<Lenient<Of>>
 
@@ -85,7 +85,7 @@ typealias LenientNewArrayExpression = AST.NewArrayExpression<Lenient<Of>, Lenien
 /** Type containing [Identity]s */
 typealias IdentityType = Type<Identity<Of>>
 /** Array containing [Identity]s */
-typealias IdentityArray = Array<Identity<Of>>
+typealias IdentityArray = Type.Array<Identity<Of>>
 /** ArrayType containing [Identity]s */
 typealias IdentityArrayType = Type.Array.ArrayType<Identity<Of>>
 
@@ -152,7 +152,7 @@ typealias IdentityNewArrayExpression = AST.NewArrayExpression<Identity<Of>, Iden
 /** Type containing [Positioned]s */
 typealias PositionedType = Type<Positioned<Of>>
 /** Array containing [Positioned]s */
-typealias PositionedArray = Array<Positioned<Of>>
+typealias PositionedArray = Type.Array<Positioned<Of>>
 /** ArrayType containing [Positioned]s */
 typealias PositionedArrayType = Type.Array.ArrayType<Positioned<Of>>
 
@@ -219,7 +219,7 @@ typealias PositionedNewArrayExpression = AST.NewArrayExpression<Positioned<Of>, 
 /** Type containing [Parsed]s */
 typealias ParsedType = Type<Parsed<Of>>
 /** Array containing [Parsed]s */
-typealias ParsedArray = Array<Parsed<Of>>
+typealias ParsedArray = Type.Array<Parsed<Of>>
 /** ArrayType containing [Parsed]s */
 typealias ParsedArrayType = Type.Array.ArrayType<Parsed<Of>>
 

--- a/src/main/kotlin/edu/kit/compiler/wrapper/Types.kt
+++ b/src/main/kotlin/edu/kit/compiler/wrapper/Types.kt
@@ -72,22 +72,6 @@ interface Kind<out F, out A> {
  */
 class Of private constructor()
 
-/**
- * This interface can be implemented for Wrappers [F], that
- * allow for extracting a contained value [A] from the wrapper.
- *
- * There is an extension function [unwrap], that can be used
- * extract the value inside a Wrapper.
- * See [WrappingExample.unwrappedValue] for an example
- *
- *
- * @sample WrappingExample
- */
-interface Unwrappable<F> {
-    fun <A> unwrapValue(fa: Kind<F, A>): A
-}
-fun <A, F> Kind<F, A>.unwrap(wrapper: Unwrappable<F>): A = wrapper.unwrapValue(this)
-
 // ---------------------------------------- Implementors ----------------------------------------//
 /**
  * extension function to fully apply `Lenient<Of>` to `A` using `Kind<Lenient<Of>, A>`
@@ -106,7 +90,36 @@ fun <A> Kind<AST.Parameter<Of>, A>.into(): AST.Parameter<A> = this as AST.Parame
  */
 fun <A, O> Kind<AST.Expression<Of, O>, A>.into(): AST.Expression<A, O> = this as AST.Expression<A, O>
 fun <E, S, O> Kind<AST.Statement<E, Of, O>, S>.into(): AST.Statement<E, S, O> = this as AST.Statement<E, S, O>
-fun <E, S, O> Kind<AST.BlockStatement<E, Of, O>, S>.into(): AST.BlockStatement<E, S, O> = this as AST.BlockStatement<E, S, O>
+fun <E, S, O> Kind<AST.BlockStatement<E, Of, O>, S>.into(): AST.BlockStatement<E, S, O> =
+    this as AST.BlockStatement<E, S, O>
+
+/**
+ * Read as "Functor *for* F"
+ */
+interface Functor<F> {
+    fun <A, B> functorMap(f: (A) -> B, fa: Kind<F, A>): Kind<F, B>
+}
+
+fun <A, B, F> Kind<F, A>.fmap(wrapper: Functor<F>, f: (A) -> B): Kind<F, B> = wrapper.functorMap(f, this)
+
+// ---------------------------------------- Unwrappable ----------------------------------------//
+
+/**
+ * This interface can be implemented for Wrappers [F], that
+ * allow for extracting a contained value [A] from the wrapper.
+ *
+ * There is an extension function [unwrap], that can be used
+ * extract the value inside a Wrapper.
+ * See [WrappingExample.unwrappedValue] for an example
+ *
+ *
+ * @sample WrappingExample
+ */
+interface Unwrappable<F> {
+    fun <A> unwrapValue(fa: Kind<F, A>): A
+}
+
+fun <A, F> Kind<F, A>.unwrap(wrapper: Unwrappable<F>): A = wrapper.unwrapValue(this)
 
 // ---------------------------------------- Code Examples ----------------------------------------//
 

--- a/src/main/kotlin/edu/kit/compiler/wrapper/wrappers/Compose.kt
+++ b/src/main/kotlin/edu/kit/compiler/wrapper/wrappers/Compose.kt
@@ -10,9 +10,9 @@ import edu.kit.compiler.wrapper.unwrap
 @JvmInline
 value class Compose<out F, out G, out A>(val unCompose: Kind<F, Kind<G, A>>) : Kind<Compose<F, G, Of>, A>
 
-fun <F, G, A> Kind<F, Kind<G, A>>.compose() = Compose(this)
+inline fun <F, G, A> Kind<F, Kind<G, A>>.compose() = Compose(this)
 
-fun <F, G, A> Kind<Compose<F, G, Of>, A>.into(): Compose<F, G, A> = this as Compose<F, G, A>
+inline fun <F, G, A> Kind<Compose<F, G, Of>, A>.into(): Compose<F, G, A> = this as Compose<F, G, A>
 
 // -------------------------- Instances ----------------------------//
 class UnwrappableCompose<F, G>(private inline val unwrapF: Unwrappable<F>, private inline val unwrapG: Unwrappable<G>) :

--- a/src/main/kotlin/edu/kit/compiler/wrapper/wrappers/Compose.kt
+++ b/src/main/kotlin/edu/kit/compiler/wrapper/wrappers/Compose.kt
@@ -1,16 +1,32 @@
 package edu.kit.compiler.wrapper.wrappers
 
+import edu.kit.compiler.wrapper.Functor
 import edu.kit.compiler.wrapper.Kind
 import edu.kit.compiler.wrapper.Of
 import edu.kit.compiler.wrapper.Unwrappable
+import edu.kit.compiler.wrapper.fmap
 import edu.kit.compiler.wrapper.unwrap
 
 @JvmInline
-value class Compose<F, G, A>(val unCompose: Kind<F, Kind<G, A>>) : Kind<Compose<F, G, Of>, A>
+value class Compose<out F, out G, out A>(val unCompose: Kind<F, Kind<G, A>>) : Kind<Compose<F, G, Of>, A>
+
+fun <F, G, A> Kind<F, Kind<G, A>>.compose() = Compose(this)
 
 fun <F, G, A> Kind<Compose<F, G, Of>, A>.into(): Compose<F, G, A> = this as Compose<F, G, A>
+
+// -------------------------- Instances ----------------------------//
 class UnwrappableCompose<F, G>(private inline val unwrapF: Unwrappable<F>, private inline val unwrapG: Unwrappable<G>) :
     Unwrappable<Compose<F, G, Of>> {
     override fun <A> unwrapValue(fa: Kind<Compose<F, G, Of>, A>): A =
         fa.into().unCompose.unwrap(unwrapF).unwrap(unwrapG)
+}
+
+class FunctorCompose<F, G>(private inline val functorF: Functor<F>, private inline val functorG: Functor<G>) :
+    Functor<Compose<F, G, Of>> {
+    override fun <A, B> functorMap(f: (A) -> B, fga: Kind<Compose<F, G, Of>, A>): Kind<Compose<F, G, Of>, B> =
+        fga.into()
+            .unCompose
+            .fmap(functorF) { ga ->
+                ga.fmap(functorG) { a -> f(a) }
+            }.compose()
 }

--- a/src/main/kotlin/edu/kit/compiler/wrapper/wrappers/Identity.kt
+++ b/src/main/kotlin/edu/kit/compiler/wrapper/wrappers/Identity.kt
@@ -1,5 +1,6 @@
 package edu.kit.compiler.wrapper.wrappers
 
+import edu.kit.compiler.wrapper.Functor
 import edu.kit.compiler.wrapper.Kind
 import edu.kit.compiler.wrapper.Of
 import edu.kit.compiler.wrapper.Unwrappable
@@ -16,4 +17,9 @@ fun <A> Kind<Identity<Of>, A>.into(): Identity<A> = this as Identity<A>
 
 object UnwrappableIdentity : Unwrappable<Identity<Of>> {
     override fun <A> unwrapValue(fa: Kind<Identity<Of>, A>) = fa.into().v
+}
+
+object FunctorIdentity : Functor<Identity<Of>> {
+    override fun <A, B> functorMap(f: (A) -> B, fa: Kind<Identity<Of>, A>): Identity<B> =
+        Identity(f(fa.into().v))
 }

--- a/src/main/kotlin/edu/kit/compiler/wrapper/wrappers/Lenient.kt
+++ b/src/main/kotlin/edu/kit/compiler/wrapper/wrappers/Lenient.kt
@@ -2,6 +2,7 @@ package edu.kit.compiler.wrapper.wrappers
 
 import edu.kit.compiler.ast.AST
 import edu.kit.compiler.ast.Type
+import edu.kit.compiler.wrapper.Functor
 import edu.kit.compiler.wrapper.IdentityBlockStatement
 import edu.kit.compiler.wrapper.IdentityClassDeclaration
 import edu.kit.compiler.wrapper.IdentityClassMember
@@ -46,6 +47,11 @@ sealed class Lenient<out A> : Kind<Lenient<Of>, A> {
         is Error -> Error(this.node?.let(m))
         is Valid -> Valid(m(this.node))
     }
+}
+
+object FunctorLenient : Functor<Lenient<Of>> {
+    override fun <A, B> functorMap(f: (A) -> B, fa: Kind<Lenient<Of>, A>): Kind<Lenient<Of>, B> =
+        fa.into().map(f)
 }
 
 inline fun <A> Lenient<A>.unwrapOr(handle: () -> A): A = when (this) {

--- a/src/main/kotlin/edu/kit/compiler/wrapper/wrappers/Parsed.kt
+++ b/src/main/kotlin/edu/kit/compiler/wrapper/wrappers/Parsed.kt
@@ -2,12 +2,12 @@ package edu.kit.compiler.wrapper
 
 import edu.kit.compiler.ast.AST
 import edu.kit.compiler.ast.Type
-import edu.kit.compiler.wrapper.wrappers.Annotated
 import edu.kit.compiler.wrapper.wrappers.Compose
-import edu.kit.compiler.wrapper.wrappers.Identity
+import edu.kit.compiler.wrapper.wrappers.FunctorAnnotated
+import edu.kit.compiler.wrapper.wrappers.FunctorCompose
+import edu.kit.compiler.wrapper.wrappers.FunctorLenient
 import edu.kit.compiler.wrapper.wrappers.Lenient
 import edu.kit.compiler.wrapper.wrappers.Positioned
-import edu.kit.compiler.wrapper.wrappers.UnwrappableAnnotated
 import edu.kit.compiler.wrapper.wrappers.into
 import edu.kit.compiler.wrapper.wrappers.mapClassW
 import edu.kit.compiler.wrapper.wrappers.mapExprW
@@ -15,6 +15,8 @@ import edu.kit.compiler.wrapper.wrappers.mapMember
 import edu.kit.compiler.wrapper.wrappers.mapMethodW
 import edu.kit.compiler.wrapper.wrappers.mapOtherW
 import edu.kit.compiler.wrapper.wrappers.mapStmt
+import edu.kit.compiler.wrapper.wrappers.mapValue
+import edu.kit.compiler.wrapper.wrappers.unwrapAnnotated
 import edu.kit.compiler.wrapper.wrappers.unwrapOr
 
 /**
@@ -24,10 +26,18 @@ import edu.kit.compiler.wrapper.wrappers.unwrapOr
  */
 typealias Parsed<A> = Compose<Positioned<Of>, Lenient<Of>, A>
 
-// -------------------------- validate ----------------------------//
-private fun <Ann, Node> Annotated<Ann, Node>.unwrapAnnotated() = this.unwrap(UnwrappableAnnotated())
+// -------------------------- Instances ----------------------------//
 
-fun Parsed<ParsedProgram>.validate(): IdentityProgram? =
+val ParsedFunctor = FunctorCompose<Positioned<Of>, Lenient<Of>>(FunctorAnnotated(), FunctorLenient)
+
+fun <A, B> Kind<Parsed<Of>, A>.fmapParsed(f: (A) -> B): Parsed<B> =
+    ParsedFunctor
+        .functorMap(f, this)
+        .into()
+
+// -------------------------- validate ----------------------------//
+
+fun Parsed<ParsedProgram>.validate(): PositionedProgram? =
     this.unCompose
         .into()
         .unwrapAnnotated()
@@ -35,108 +45,101 @@ fun Parsed<ParsedProgram>.validate(): IdentityProgram? =
         .unwrapOr { return null }
         .validate()
 
-fun ParsedProgram.validate(): IdentityProgram? =
+fun ParsedProgram.validate(): PositionedProgram? =
     this.mapClassW { parsed ->
         parsed
             .into()
             .unCompose
-            .into()
-            .unwrapAnnotated()
-            .into()
-            .unwrapOr { return null }
-            .validate()
-            .let {
-                it ?: return null
-            }.let {
-                Identity(it)
+            .mapValue {
+                it.into()
+                    .unwrapOr { return null }
+                    .validate()
+                    .let {
+                        it ?: return null
+                    }
             }
     }
 
-fun ParsedClassDeclaration.validate(): IdentityClassDeclaration? =
+fun ParsedClassDeclaration.validate(): PositionedClassDeclaration? =
     this.mapMethodW { parsed ->
         parsed
             .into()
             .unCompose
-            .into()
-            .unwrapAnnotated()
-            .into()
-            .unwrapOr { return null }
-            .validate()
-            .let {
-                it ?: return null
-            }.let {
-                Identity(it)
+            .mapValue {
+                it.into()
+                    .unwrapOr { return null }
+                    .validate()
+                    .let {
+                        it ?: return null
+                    }
             }
     }
 
-fun ParsedClassMember.validate(): IdentityClassMember? =
+fun ParsedClassMember.validate(): PositionedClassMember? =
     this.mapMember(
         { parsed ->
             parsed.into()
                 .unCompose
-                .into()
-                .unwrapAnnotated()
-                .into()
-                .unwrapOr { return null }
-                .into()
-                .validate()
-                .let { it ?: return null }
-                .let { Identity(it) }
+                .mapValue {
+                    it.into()
+                        .unwrapOr { return null }
+                        .into()
+                        .validate()
+                        .let { it ?: return null }
+                }
         },
         { parsed ->
             parsed.into()
                 .unCompose
-                .into()
-                .unwrapAnnotated()
-                .into()
-                .unwrapOr { return null }
-                .into()
-                .validate()
-                .let { it ?: return null }
-                .let { Identity(it) }
+                .mapValue {
+                    it.into()
+                        .unwrapOr { return null }
+                        .into()
+                        .validate()
+                        .let { it ?: return null }
+                }
         },
         { parsed ->
             parsed
                 .into()
                 .unCompose
-                .into()
-                .unwrapAnnotated()
-                .into()
-                .unwrapOr { return null }
-                .validate()
-                .let { it ?: return null }
-                .let { Identity(it) }
+                .mapValue {
+                    it.into()
+                        .unwrapOr { return null }
+                        .validate()
+                        .let { it ?: return null }
+                }
         }
     )
 
-fun ParsedBlock.validate(): IdentityBlock? =
+fun ParsedBlock.validate(): PositionedBlock? =
     this.mapStmt { parsed ->
         parsed.into()
             .unCompose
-            .into()
-            .unwrapAnnotated()
-            .into()
-            .unwrapOr { return null }
-            .into()
-            .validate()
-            .let { it ?: return null }
-            .let {
-                Identity(it)
+            .mapValue {
+                it.into()
+                    .unwrapOr { return null }
+                    .into()
+                    .validate()
+                    .let { it ?: return null }
             }
     }
 
-fun ParsedBlockStatement.validate(): IdentityBlockStatement? =
+fun ParsedBlockStatement.validate(): PositionedBlockStatement? =
     when (this) {
         is AST.LocalVariableDeclarationStatement ->
             AST.LocalVariableDeclarationStatement(
                 name,
-                type.into().unCompose.into().unwrapAnnotated().into().unwrapOr { return null }.into().validate()
-                    .let { it ?: return null }.let
-                    { Identity(it) },
+                type.into().unCompose.mapValue {
+                    it.into().unwrapOr { return null }.into().validate()
+                        .let { it ?: return null }
+                },
                 initializer?.let { justInitializer ->
-                    justInitializer.into().unCompose.into().unwrapAnnotated().into().unwrapOr { return null }.into()
-                        .validate()
-                        .let { it ?: return null }.let { Identity(it) }
+                    justInitializer.into().unCompose.mapValue {
+                        it.into().unwrapOr { return null }.into()
+                            .validate()
+                            .let { it ?: return null }
+                    }
                 }
             )
         is AST.StmtWrapper -> AST.StmtWrapper(
@@ -145,127 +148,124 @@ fun ParsedBlockStatement.validate(): IdentityBlockStatement? =
                     parsed
                         .into()
                         .unCompose
-                        .into()
-                        .unwrapAnnotated()
-                        .into()
-                        .unwrapOr { return null }
-                        .into()
-                        .validate()
-                        .let { it ?: return null }
-                        .let { Identity(it) }
+                        .mapValue {
+                            it.into()
+                                .unwrapOr { return null }
+                                .into()
+                                .validate()
+                                .let { it ?: return null }
+                        }
                 },
                 { parsed ->
                     parsed
                         .into()
                         .unCompose
-                        .into()
-                        .unwrapAnnotated()
-                        .into()
-                        .unwrapOr { return null }
-                        .into()
-                        .validate()
-                        .let { it ?: return null }
-                        .let { Identity(it) }
+                        .mapValue {
+                            it.into()
+                                .unwrapOr { return null }
+                                .into()
+                                .validate()
+                                .let { it ?: return null }
+                        }
                 }, { parsed ->
-                parsed.into().unCompose.into().unwrapAnnotated().into().unwrapOr { return null }.into().validate()
-                    .let { it ?: return null }.let { Identity(it) }
+                parsed.into().unCompose.mapValue {
+                    it.into().unwrapOr { return null }.into().validate()
+                        .let { it ?: return null }
+                }
             }
             )
         )
     }
 
-fun ParsedStatement.validate(): IdentityStatement? =
+fun ParsedStatement.validate(): PositionedStatement? =
     this.mapStmt(
         { parsed ->
             parsed.into()
                 .unCompose
-                .into()
-                .unwrapAnnotated()
-                .into()
-                .unwrapOr { return null }
-                .into()
-                .validate()
-                .let { it ?: return null }
-                .let { Identity(it) }
+                .mapValue {
+                    it.into()
+                        .unwrapOr { return null }
+                        .into()
+                        .validate()
+                        .let { it ?: return null }
+                }
         },
         { parsed ->
             parsed.into()
                 .unCompose
-                .into()
-                .unwrapAnnotated()
-                .into()
+                .mapValue {
+                    it.into()
+                        .unwrapOr { return null }
+                        .into()
+                        .validate()
+                        .let { it ?: return null }
+                }
+        }, { parsed ->
+        parsed.into()
+            .unCompose
+            .mapValue {
+                it.into()
+                    .unwrapOr { return null }
+                    .into()
+                    .validate()
+                    .let { it ?: return null }
+            }
+    }
+    )
+
+fun ParsedExpression.validate(): PositionedExpression? =
+    this.mapExprW({ parsed ->
+        parsed
+            .into().unCompose.mapValue {
+                it.into()
+                    .unwrapOr { return null }
+                    .into()
+                    .validate()
+                    .let { it ?: return null }
+            }
+    }, { parsed ->
+        parsed
+            .into().unCompose.into().mapValue {
+                it.into()
+                    .unwrapOr { return null }
+                    .into()
+                    .validate()
+                    .let { it ?: return null }
+            }
+    })
+
+fun ParsedArrayType.validate(): PositionedArrayType? =
+    this
+        .elementType
+        .into().unCompose.into().mapValue {
+            it.into()
                 .unwrapOr { return null }
                 .into()
                 .validate()
                 .let { it ?: return null }
-                .let { Identity(it) }
-        }, { parsed ->
-        parsed.into()
-            .unCompose
-            .into()
-            .unwrapAnnotated()
-            .into()
-            .unwrapOr { return null }
-            .into()
-            .validate()
-            .let { it ?: return null }
-            .let { Identity(it) }
-    }
-    )
+        }.let { Type.Array.ArrayType(it) }
 
-fun ParsedExpression.validate(): IdentityExpression? =
-    this.mapExprW({ parsed ->
-        parsed
-            .into().unCompose.into().unwrapAnnotated().into()
-            .unwrapOr { return null }
-            .into()
-            .validate()
-            .let { it ?: return null }
-            .let { Identity(it) }
-    }, { parsed ->
-        parsed
-            .into().unCompose.into().unwrapAnnotated().into()
-            .unwrapOr { return null }
-            .into()
-            .validate()
-            .let { it ?: return null }
-            .let { Identity(it) }
-    })
-
-fun ParsedArrayType.validate(): IdentityArrayType? =
-    this
-        .elementType
-        .into().unCompose.into().unwrapAnnotated().into()
-        .unwrapOr { return null }
-        .into()
-        .validate()
-        .let { it ?: return null }
-        .let { Identity(it) }
-        .let { Type.Array.ArrayType(it) }
-
-fun ParsedParameter.validate(): IdentityParameter? =
+fun ParsedParameter.validate(): PositionedParameter? =
     this.mapOtherW { parsed ->
         parsed.into()
             .unCompose
-            .into()
-            .unwrapAnnotated()
-            .into()
-            .unwrapOr { return null }
-            .into()
-            .validate()
-            .let { it ?: return null }
-            .let { Identity(it) }
+            .mapValue {
+                it.into()
+                    .unwrapOr { return null }
+                    .into()
+                    .validate()
+                    .let { it ?: return null }
+            }
     }
 
-fun ParsedType.validate(): IdentityType? = this.mapOtherW {
+fun ParsedType.validate(): PositionedType? = this.mapOtherW {
     it.into()
         .unCompose
-        .into()
-        .unwrapAnnotated()
-        .into()
-        .unwrapOr { return null }
-        .into()
-        .validate()
-        .let { it ?: return null }
-        .let { Identity(it) }
+        .mapValue {
+            it.into()
+                .unwrapOr { return null }
+                .into()
+                .validate()
+                .let { it ?: return null }
+        }
 }

--- a/src/main/kotlin/edu/kit/compiler/wrapper/wrappers/Wrappers.kt
+++ b/src/main/kotlin/edu/kit/compiler/wrapper/wrappers/Wrappers.kt
@@ -1,22 +1,44 @@
 package edu.kit.compiler.wrapper.wrappers
 
 import edu.kit.compiler.lex.SourceRange
+import edu.kit.compiler.wrapper.Functor
 import edu.kit.compiler.wrapper.Kind
 import edu.kit.compiler.wrapper.Of
 import edu.kit.compiler.wrapper.Unwrappable
+import edu.kit.compiler.wrapper.unwrap
 
 /**
  * Wrapper type, that adds a type annotation to the contained value
  */
-data class Annotated<Ann, Node>(val node: Node, val ann: Ann) : Kind<Annotated<Ann, Of>, Node> {
-    inline fun <B> mapAnnotation(f: (Ann) -> B) = Annotated(node, f(ann))
-}
+data class Annotated<Ann, Val>(val value: Val, val annotation: Ann) : Kind<Annotated<Ann, Of>, Val>
 
-fun <Ann, Node> Kind<Annotated<Ann, Of>, Node>.into(): Annotated<Ann, Node> = this as Annotated<Ann, Node>typealias Positioned<Node> = Annotated<SourceRange, Node>
+inline fun <A, Ann1, Ann2> Kind<Annotated<Ann1, Of>, A>.mapAnnotation(f: (Ann1) -> Ann2): Annotated<Ann2, A> =
+    Annotated(this.into().value, f(annotation))
 
-fun <Node> Node.positioned(range: SourceRange): Positioned<Node> = Annotated(this, range)
+inline fun <A, B, Ann> Kind<Annotated<Ann, Of>, A>.mapValue(f: (A) -> B): Annotated<Ann, B> =
+    this.into().run { Annotated(f(value), annotation) }
+
+fun <Ann, Node> Kind<Annotated<Ann, Of>, Node>.into(): Annotated<Ann, Node> = this as Annotated<Ann, Node>
 
 @JvmInline
 value class UnwrappableAnnotated<Ann>(val empty: Unit? = null) : Unwrappable<Annotated<Ann, Of>> {
-    override fun <A> unwrapValue(fa: Kind<Annotated<Ann, Of>, A>) = fa.into().node
+    override fun <A> unwrapValue(fa: Kind<Annotated<Ann, Of>, A>) = fa.into().value
 }
+
+fun <Ann, Node> Annotated<Ann, Node>.unwrapAnnotated() = this.unwrap(UnwrappableAnnotated())
+
+@JvmInline
+value class FunctorAnnotated<Ann>(val empty: Unit? = null) : Functor<Annotated<Ann, Of>> {
+    override fun <A, B> functorMap(f: (A) -> B, fa: Kind<Annotated<Ann, Of>, A>): Kind<Annotated<Ann, Of>, B> =
+        fa.mapValue(f)
+}
+
+val <Node, Ann> Kind<Annotated<Ann, Of>, Node>.annotation: Ann get() = this.into().annotation
+val <Node, Ann> Kind<Annotated<Ann, Of>, Node>.annotationValue: Node get() = this.into().value
+
+// Positioned
+typealias Positioned<Node> = Annotated<SourceRange, Node>
+
+fun <Node> Node.positioned(range: SourceRange): Positioned<Node> = Annotated(this, range)
+
+val PositionedUnwrapper = UnwrappableAnnotated<SourceRange>()

--- a/src/main/kotlin/edu/kit/compiler/wrapper/wrappers/Wrappers.kt
+++ b/src/main/kotlin/edu/kit/compiler/wrapper/wrappers/Wrappers.kt
@@ -18,14 +18,14 @@ inline fun <A, Ann1, Ann2> Kind<Annotated<Ann1, Of>, A>.mapAnnotation(f: (Ann1) 
 inline fun <A, B, Ann> Kind<Annotated<Ann, Of>, A>.mapValue(f: (A) -> B): Annotated<Ann, B> =
     this.into().run { Annotated(f(value), annotation) }
 
-fun <Ann, Node> Kind<Annotated<Ann, Of>, Node>.into(): Annotated<Ann, Node> = this as Annotated<Ann, Node>
+inline fun <Ann, Node> Kind<Annotated<Ann, Of>, Node>.into(): Annotated<Ann, Node> = this as Annotated<Ann, Node>
 
 @JvmInline
 value class UnwrappableAnnotated<Ann>(val empty: Unit? = null) : Unwrappable<Annotated<Ann, Of>> {
     override fun <A> unwrapValue(fa: Kind<Annotated<Ann, Of>, A>) = fa.into().value
 }
 
-fun <Ann, Node> Annotated<Ann, Node>.unwrapAnnotated() = this.unwrap(UnwrappableAnnotated())
+inline fun <Ann, Node> Annotated<Ann, Node>.unwrapAnnotated() = this.unwrap(UnwrappableAnnotated())
 
 @JvmInline
 value class FunctorAnnotated<Ann>(val empty: Unit? = null) : Functor<Annotated<Ann, Of>> {
@@ -39,6 +39,6 @@ val <Node, Ann> Kind<Annotated<Ann, Of>, Node>.annotationValue: Node get() = thi
 // Positioned
 typealias Positioned<Node> = Annotated<SourceRange, Node>
 
-fun <Node> Node.positioned(range: SourceRange): Positioned<Node> = Annotated(this, range)
+inline fun <Node> Node.positioned(range: SourceRange): Positioned<Node> = Annotated(this, range)
 
 val PositionedUnwrapper = UnwrappableAnnotated<SourceRange>()

--- a/src/test/kotlin/edu/kit/compiler/parser/ExpressionParseTest.kt
+++ b/src/test/kotlin/edu/kit/compiler/parser/ExpressionParseTest.kt
@@ -2,6 +2,7 @@ package edu.kit.compiler.parser
 
 import edu.kit.compiler.ast.AST
 import edu.kit.compiler.utils.TestUtils.expectNode
+import edu.kit.compiler.utils.TestUtils.parsedToLenient
 import edu.kit.compiler.utils.toSymbol
 import edu.kit.compiler.wrapper.Of
 import edu.kit.compiler.wrapper.wrappers.Lenient
@@ -13,7 +14,7 @@ internal class ExpressionParseTest {
     private val emptyAnchorSet = anchorSetOf().intoUnion()
 
     private fun expectAst(input: String, expectedAST: Lenient<AST.Expression<Lenient<Of>, Lenient<Of>>>) =
-        expectNode(input, expectedAST) { parseExpression(anc = emptyAnchorSet) }
+        expectNode(input, expectedAST) { parseExpression(anc = emptyAnchorSet).parsedToLenient() }
 
     @Test
     fun testParseLiteral() = expectAst("1", AST.LiteralExpression("1").wrapValid())

--- a/src/test/kotlin/edu/kit/compiler/parser/MixedParseTest.kt
+++ b/src/test/kotlin/edu/kit/compiler/parser/MixedParseTest.kt
@@ -5,6 +5,7 @@ import edu.kit.compiler.ast.AST.wrapBlockStatement
 import edu.kit.compiler.ast.Type
 import edu.kit.compiler.ast.astOf
 import edu.kit.compiler.utils.TestUtils.expectNode
+import edu.kit.compiler.utils.TestUtils.parsedToLenient
 import edu.kit.compiler.utils.toSymbol
 import edu.kit.compiler.wrapper.LenientBlock
 import edu.kit.compiler.wrapper.LenientClassDeclaration
@@ -26,11 +27,11 @@ internal class MixedParseTest {
     ).wrapBlockStatement().wrapValid()
 
     private fun expectAst(input: String, expectedAST: List<Lenient<LenientClassDeclaration>>) =
-        expectNode(input, expectedAST) { parseClassDeclarations(emptyAnchorSet) }
+        expectNode(input, expectedAST) { parseClassDeclarations(emptyAnchorSet).map { it.parsedToLenient() } }
 
     @Test
     fun testParseEmptyBlock() =
-        expectNode("{}", validEmptyBlock) { parseBlock(emptyAnchorSet) }
+        expectNode("{}", validEmptyBlock) { parseBlock(emptyAnchorSet).parsedToLenient() }
 
     @Test
     fun testParseBlockOfEmptyBlocks() =
@@ -46,11 +47,11 @@ internal class MixedParseTest {
                 )
             )
                 .wrapValid()
-        ) { parseBlock(emptyAnchorSet) }
+        ) { parseBlock(emptyAnchorSet).parsedToLenient() }
 
     @Test
     fun testParseBlockWithEmptyStatement() =
-        expectNode("{;}", AST.Block(listOf(validEmptyBlockStatement)).wrapValid()) { parseBlock(emptyAnchorSet) }
+        expectNode("{;}", AST.Block(listOf(validEmptyBlockStatement)).wrapValid()) { parseBlock(emptyAnchorSet).parsedToLenient() }
 
     @Test
     fun testParseBlockWithMultipleEmptyStatement() = expectNode(
@@ -63,7 +64,7 @@ internal class MixedParseTest {
                 validEmptyBlockStatement,
             )
         ).wrapValid()
-    ) { parseBlock(emptyAnchorSet) }
+    ) { parseBlock(emptyAnchorSet).parsedToLenient() }
 
     @Test
     fun testDisambiguateVarDeclarationAndExpression() = expectNode(
@@ -80,7 +81,7 @@ internal class MixedParseTest {
                     .wrapValid()
             )
         ).wrapValid()
-    ) { parseBlock(emptyAnchorSet) }
+    ) { parseBlock(emptyAnchorSet).parsedToLenient() }
 
     @Test
     fun testParseAssignment() = expectNode(
@@ -92,19 +93,19 @@ internal class MixedParseTest {
                 AST.BinaryExpression.Operation.ASSIGNMENT
             ).wrapValid()
         ).wrapValid()
-    ) { parseStatement(emptyAnchorSet) }
+    ) { parseStatement(emptyAnchorSet).parsedToLenient() }
 
     @Test
     fun testParseReturn() = expectNode(
         "return;",
         AST.ReturnStatement<Lenient<Of>, Lenient<Of>>(null).wrapValid()
-    ) { parseStatement(emptyAnchorSet) }
+    ) { parseStatement(emptyAnchorSet).parsedToLenient() }
 
     @Test
     fun testParseReturnValue() = expectNode(
         "return(2);",
         AST.ReturnStatement(AST.LiteralExpression("2").wrapValid()).wrapValid()
-    ) { parseStatement(emptyAnchorSet) }
+    ) { parseStatement(emptyAnchorSet).parsedToLenient() }
 
     @Test
     fun testParseBasicWhile() = expectNode(
@@ -113,7 +114,7 @@ internal class MixedParseTest {
             AST.LiteralExpression("2").wrapValid(),
             validEmptyBlock
         ).wrapValid()
-    ) { parseStatement(emptyAnchorSet) }
+    ) { parseStatement(emptyAnchorSet).parsedToLenient() }
 
     @Test
     fun testParseBasicIf() = expectNode(
@@ -123,7 +124,7 @@ internal class MixedParseTest {
             validEmptyBlock,
             null
         ).wrapValid()
-    ) { parseStatement(emptyAnchorSet) }
+    ) { parseStatement(emptyAnchorSet).parsedToLenient() }
 
     @Test
     fun testParseBasicIfElse() = expectNode(
@@ -133,7 +134,7 @@ internal class MixedParseTest {
             validEmptyBlock,
             validEmptyBlock
         ).wrapValid()
-    ) { parseStatement(emptyAnchorSet) }
+    ) { parseStatement(emptyAnchorSet).parsedToLenient() }
 
     @Test
     fun testParseBasicIfElse_bool() = expectNode(
@@ -143,7 +144,7 @@ internal class MixedParseTest {
             validEmptyBlock,
             validEmptyBlock
         ).wrapValid()
-    ) { parseStatement(emptyAnchorSet) }
+    ) { parseStatement(emptyAnchorSet).parsedToLenient() }
 
     @Test
     fun testParseBasicIfElse_ident() = expectNode(
@@ -153,7 +154,7 @@ internal class MixedParseTest {
             validEmptyBlock,
             validEmptyBlock
         ).wrapValid()
-    ) { parseStatement(emptyAnchorSet) }
+    ) { parseStatement(emptyAnchorSet).parsedToLenient() }
 
     @Test
     fun debugParserMJTest_2() = expectNode(
@@ -211,7 +212,7 @@ internal class MixedParseTest {
                 ).wrapValid()
             )
         ).wrapValid()
-    ) { parse() }
+    ) { parse().parsedToLenient() }
 
     @Test
     fun debugParserMJTest_4() {
@@ -272,7 +273,7 @@ internal class MixedParseTest {
                 )
             ).wrapValid()
 
-        ) { parse() }
+        ) { parse().parsedToLenient() }
     }
 
     //    @Ignore
@@ -320,7 +321,7 @@ internal class MixedParseTest {
                 ).wrapValid()
             )
         ).wrapValid()
-    ) { parse() }
+    ) { parse().parsedToLenient() }
 
     @Ignore
     @Test
@@ -392,7 +393,7 @@ internal class MixedParseTest {
             )
         ).wrapValid()
 
-    ) { parse() }
+    ) { parse().parsedToLenient() }
 
     @Test
     fun debugParserMJTest_1() = expectNode(
@@ -445,7 +446,7 @@ internal class MixedParseTest {
             )
         ).wrapValid()
 
-    ) { parse() }
+    ) { parse().parsedToLenient() }
 
     @Test
     fun testBasicBlock() = expectAst(

--- a/src/test/kotlin/edu/kit/compiler/parser/PrettyPrintMJTestSuite.kt
+++ b/src/test/kotlin/edu/kit/compiler/parser/PrettyPrintMJTestSuite.kt
@@ -1,6 +1,5 @@
 package edu.kit.compiler.parser
 
-import edu.kit.compiler.ast.AST
 import edu.kit.compiler.ast.PrettyPrintVisitor
 import edu.kit.compiler.ast.accept
 import edu.kit.compiler.initializeKeywords
@@ -9,9 +8,8 @@ import edu.kit.compiler.lex.SourceFile
 import edu.kit.compiler.lex.StringTable
 import edu.kit.compiler.utils.TestUtils
 import edu.kit.compiler.utils.createLexer
-import edu.kit.compiler.wrapper.Of
+import edu.kit.compiler.wrapper.PositionedProgram
 import edu.kit.compiler.wrapper.validate
-import edu.kit.compiler.wrapper.wrappers.Identity
 import edu.kit.compiler.wrapper.wrappers.validate
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.params.ParameterizedTest
@@ -83,7 +81,7 @@ internal class PrettyPrintMJTestSuite {
         }
     }
 
-    fun prettyPrint(astRoot: AST.Program<Identity<Of>, Identity<Of>, Identity<Of>, Identity<Of>, Identity<Of>>): String {
+    fun prettyPrint(astRoot: PositionedProgram): String {
         val byteArrayOutputStream: ByteArrayOutputStream = ByteArrayOutputStream()
         val utf8: String = StandardCharsets.UTF_8.name()
         val printStream = PrintStream(byteArrayOutputStream, true, utf8)
@@ -94,7 +92,7 @@ internal class PrettyPrintMJTestSuite {
     }
 
     @OptIn(ExperimentalStdlibApi::class)
-    fun createAST(input: String): AST.Program<Identity<Of>, Identity<Of>, Identity<Of>, Identity<Of>, Identity<Of>> {
+    fun createAST(input: String): PositionedProgram {
         val (lexer, sourceFile) = createLexer(input)
         return Parser(sourceFile, lexer.tokens()).parse().validate()!!
     }

--- a/src/test/kotlin/edu/kit/compiler/parser/RegressionTest.kt
+++ b/src/test/kotlin/edu/kit/compiler/parser/RegressionTest.kt
@@ -2,6 +2,7 @@ package edu.kit.compiler.parser
 
 import edu.kit.compiler.error.AnnotationFormatter
 import edu.kit.compiler.utils.createLexer
+import edu.kit.compiler.wrapper.validate
 import edu.kit.compiler.wrapper.wrappers.validate
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals


### PR DESCRIPTION
- [x] Basic setup implemented `Parsed<...>` and `ParsedExpression` aliases
- [x] `.positioned(...)` extension function
- [x] `validate` for `Parsed<...>`
- [x] Add source spans in parsed. Example of how that would look can be found in `parseBasicType`