### PR TITLE
Remove Bad nodes after construction

### DIFF
--- a/src/main/kotlin/edu/kit/compiler/transform/FirmContext.kt
+++ b/src/main/kotlin/edu/kit/compiler/transform/FirmContext.kt
@@ -187,6 +187,10 @@ object FirmContext {
         this.graph = null
         this.returnNodes.clear()
         this.exitBlocks.clear()
+
+        // unreachable returns may introduce Bad nodes, remove them before subsequent phases
+        firm.bindings.binding_irgopt.remove_bads(graph.ptr)
+
         return graph
     }
 


### PR DESCRIPTION
Unreachable returns introduce Bad nodes, but subsequent phases require a clean graph, so remove them after construction.